### PR TITLE
ci: add auto-release workflow on tag push

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,14 @@
+name: auto-release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  tests:
+    uses: ./.github/workflows/tests.yml
+
+  release:
+    needs: [tests]
+    uses: brickhouse-tech/.github/.github/workflows/auto-release.yml@main


### PR DESCRIPTION
Adds auto-release workflow: on `v*` tag push → run tests → create GitHub Release with auto-generated notes.

Uses the shared reusable workflow from brickhouse-tech/.github.