### PR TITLE
ci: enable Dependabot auto-merge with PAT so releases cascade

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -27,4 +27,4 @@ jobs:
         run: gh pr merge --squash --auto "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Swaps the merge step's token to `${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}` so a Dependabot auto-merge re-triggers release.yml (GITHUB_TOKEN merges don't). Requires GH_TOKEN as a Dependabot secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)