### PR TITLE
fix(deps): resolve Dependabot CVEs — yaml.v3 3.0.1, x/sys v0.47.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nmccready/aws-sdk-go-v2-ifaces
 
-go 1.24
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.50.1
@@ -453,6 +453,6 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.1.0 // indirect
-	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+	golang.org/x/sys v0.47.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Resolves both open Dependabot alerts:

- **CVE-2022-28948** (high) — `gopkg.in/yaml.v3` → **v3.0.1** (DoS in Unmarshal)
- **CVE-2022-29526** (medium) — `golang.org/x/sys` 2019 snapshot → **v0.47.0** (incorrect privilege reporting in syscall)

Both were indirect deps pinned by the legacy testify/go-debug chain; bumped directly in go.mod. The `go` directive moves 1.24 → 1.25.0 (required by x/sys), which matches `.prototools` (go = "1.25"). `go.sum` is gitignored in this repo, so go.mod is the only change.

Full `go build ./...` + `go test ./...` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)